### PR TITLE
fixes issue #7 use -E for extended regexp support

### DIFF
--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -25,10 +25,10 @@ fi
 
 [[ -d "$versionShort" ]] || mkdir "$versionShort"
 
-sed -r -e 's!%%PARENT%%!'"$parent"'!g' "./Dockerfile.template" > "./$versionShort/Dockerfile"
-sed -i 's/%%MAIN_VERSION%%/'"${version}"'/g' "./${versionShort}/Dockerfile"
-sed -i 's/%%VERSION_MINOR%%/'"${versionShort}"'/g' "./${versionShort}/Dockerfile"
-sed -i 's!%%MAIN_SHA%%!'"$sha"'!g' "./$versionShort/Dockerfile"
+sed -E -e 's!%%PARENT%%!'"$parent"'!g' "./Dockerfile.template" > "./$versionShort/Dockerfile"
+sed -i -E 's/%%MAIN_VERSION%%/'"${version}"'/g' "./${versionShort}/Dockerfile"
+sed -i -E 's/%%VERSION_MINOR%%/'"${versionShort}"'/g' "./${versionShort}/Dockerfile"
+sed -i -E 's!%%MAIN_SHA%%!'"$sha"'!g' "./$versionShort/Dockerfile"
 
 string="$string --file $versionShort/Dockerfile"
 


### PR DESCRIPTION
Ran into issues running on macOS (see #7)  This fixes it by using -E flag on sed.