### PR TITLE
Add shared Node variant.

### DIFF
--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -44,3 +44,32 @@ fi
 string="$string ."
 
 echo "$string" >> ./build-images.sh
+
+
+# Build a Dockerfile for each variant
+# Currently this only supports shared variants, not local variants
+
+for variant in "${variants[@]}"
+do
+	# If version/variant directory doesn't exist, create it
+	[[ -d "${versionShort}/${variant}" ]] || mkdir "${versionShort}/${variant}"
+
+	sed -e 's!%%PARENT%%!'"$repository"'!g' "./shared/variants/${variant}.Dockerfile.template" > "./${versionShort}/${variant}/Dockerfile"
+	sed -i.bak 's/%%PARENT_TAG%%/'"${version}"'/g' "./${versionShort}/${variant}/Dockerfile"
+done
+
+# This .bak thing above and below is a Linux/macOS compatibility fix
+rm "./${versionShort}/${variant}/Dockerfile.bak"
+
+string="docker build"
+string="$string --file ${versionShort}/${variant}/Dockerfile"
+
+string="${string} -t ${tagless_image}:${version}-${variant}"
+
+if [[ $versionShort != "$version" ]]; then
+	string="${string}  -t ${tagless_image}:${versionShort}-${variant}"
+fi
+
+string="$string ."
+
+echo "$string" >> ./build-images.sh

--- a/variants/node.Dockerfile.template
+++ b/variants/node.Dockerfile.template
@@ -1,0 +1,22 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/%%PARENT%%:%%PARENT_TAG%%
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Version hardcoded for now in this repo. Eventually once:
+# https://github.com/CircleCI-Public/cimg-node/issues/16 is completed, this
+# Dockerfile will pull the latest LTS release from cimg-node.
+ENV NODE_VERSION 12.16.1
+
+RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.4
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg


### PR DESCRIPTION
- adds support for cimg variants through the shared build tools (this repo)
- adds support for a shared node variant using the LTS Node release
- designed to override shared variants with local variants (not a thing at the moment)
- uses the variants Bash array already available in most next-gen images
- works with 2/3rd party images (not a thing at the moment)