### PR TITLE
Advanced version support for alias and params.

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,20 +1,53 @@
 #!/usr/bin/env bash
 
-versions=( "$@" )
+# Much of the version processing logic is repeated from gen-dockerfiles.sh
+# This should be de-duped sometime in the future when this logic is solidified
+versions=()
 
-sortedVersions=$(
-	for version in "${versions[@]}"; do
-		echo "$version"
-	done | sort --reverse)
+for versionGroup in "$@"; do
 
+	# Process the version group(s) that were passed to this script.
+	if [[ "$versionGroup" == *"#"* ]]; then
+		vgParam1=$(cut -d "#" -f2- <<< "$versionGroup")
+		versionGroup="${versionGroup//$vgParam1}"
+		versionGroup="${versionGroup//\#}"
+	fi
 
-for i in "${!sortedVersions[@]}"; do
+	if [[ "$versionGroup" == *"="* ]]; then
+		vgAlias1=$(cut -d "=" -f2- <<< "$versionGroup")
+		versionGroup="${versionGroup//$vgAlias1}"
+		versionGroup="${versionGroup//=}"
+	fi
 
-	version=${sortedVersions[$i]}
-
-	git checkout -b "release-v${version}"
-	shared/gen-dockerfiles.sh "${version}" fake-sha
-	git add .
-	git commit -m "Add v${version}. [release]"
-	git push -u origin "release-v${version}"
+	vgVersion=$(cut -d "v" -f2- <<< "$versionGroup")
+	versions+=( "$vgVersion" )
 done
+
+branchName=""
+commitMSG=""
+
+if [[ ${#versions[@]} == 0 ]]; then
+	echo "Error, no versions detected."
+	exit 1
+elif [[ ${#versions[@]} == 1 ]]; then
+	branchName="release-v${versions[0]}"
+	commitMSG="Publish v${versions[0]}. [release]"
+elif [[ ${#versions[@]} == 2 ]]; then
+	branchName="release-v${versions[0]}-and-v${versions[1]}"
+	commitMSG="Publish v${versions[0]} and v${versions[1]}. [release]"
+elif [[ ${#versions[@]} == 3 ]]; then
+	branchName="release-v${versions[0]}-v${versions[1]}-and-more"
+	commitMSG="Publish v${versions[0]}, v${versions[1]}, and v${versions[2]}. [release]"
+elif [[ ${#versions[@]} == 4 ]]; then
+	branchName="release-v${versions[0]}-v${versions[1]}-and-more"
+	commitMSG="Pub: v${versions[0]}, v${versions[1]}, v${versions[2]}, and more. [release]"
+elif [[ ${#versions[@]} -gt 4 ]]; then
+	branchName="release-v${versions[0]}-v${versions[1]}-and-more"
+	commitMSG="Pub: ${versions[0]},${versions[1]},${versions[2]},${versions[3]}, and more. [release]"
+fi
+
+git checkout -b "${branchName}" master
+shared/gen-dockerfiles.sh "$@"
+git add .
+git commit -m "${commitMSG}"
+git push -u origin "${branchName}"


### PR DESCRIPTION
This PR completely reworks how `cimg-shared` handles version numbers on the command-line. The logic in this repository is handled by two scripts, `release.sh` and `gen-dockerfiles.sh`. Both have been updated to improve support, fix a bug, and lay the ground work for future features.

What in this PR:

1. `gen-dockerfiles.sh` now supports being passed multiple versions at once.
2. `release.sh` always supported multiple versions but it didn't work before num. 1 above. Now it has been adjusted to work in conjunction with `gen-dockerfiles.sh`.
3. `release.sh` now supports being passed an additional parameter the way `gen-dockerfiles.sh` has. Both now refer to this as `param1` rather than `sha`. The more broad naming allows it to be used for more situations such as the download URL for the `cimg-openjdk` builds.
4. These scripts now have a concept of version groups. They can be passed just a version, or a version with a combination of an alias (for Docker tag purposes) or a generic parameter which can be anything that the Dockerfile templates might need. Versions can now also be prefixed with a `v`.
5. A bug fix. A recent PR in this repo enabled support for shared variants for images. This created a bug for images that doesn't currently have a variant (i.e. cimg-node) in which is was trying to process variants that weren't there. This PR fixes that.

What's Not in this PR:

1. Full alias support. The ground work for supporting aliases is in this PR, but the work to actually pass that info to Docker and eventually Docker Hub is not yet done. That will follow once this PR is merged.


Closes #15, closes #14, and closes #1.