### PR TITLE
Add alias support.

### DIFF
--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -61,6 +61,7 @@ for versionGroup in "$@"; do
 	sed -i.bak 's/%%VERSION_MINOR%%/'"${versionShort}"'/g' "./${versionShort}/Dockerfile"
 	sed -i.bak 's!%%MAIN_SHA%%!'"$vgParam1"'!g' "./$versionShort/Dockerfile"  # will be deprecated in the future
 	sed -i.bak 's!%%PARAM1%%!'"$vgParam1"'!g' "./$versionShort/Dockerfile"
+	sed -i.bak 's!%%ALIAS1%%!'"$vgAlias1"'!g' "./$versionShort/Dockerfile"
 
 	# This .bak thing above and below is a Linux/macOS compatibility fix
 	rm "./${versionShort}/Dockerfile.bak"
@@ -71,6 +72,10 @@ for versionGroup in "$@"; do
 
 	if [[ $versionShort != "$vgVersion" ]]; then
 		string="${string}  -t ${tagless_image}:${versionShort}"
+	fi
+
+	if [[ -n $vgAlias1 ]]; then
+		string="${string}  -t ${tagless_image}:${vgAlias1}"
 	fi
 
 	string="$string ."
@@ -97,6 +102,10 @@ for versionGroup in "$@"; do
 
 		if [[ $versionShort != "$vgVersion" ]]; then
 			string="${string}  -t ${tagless_image}:${versionShort}-${variant}"
+		fi
+
+		if [[ -n $vgAlias1 ]]; then
+			string="${string}  -t ${tagless_image}:${vgAlias1}-${variant}"
 		fi
 
 		string="$string ."


### PR DESCRIPTION
Adds support for version aliases. The shining use case is for Node.js where as of today (April 24th) Node.js v14.0.0 is "current" and v12.16.2 is "LTS".

This PR enables this feature for both the standard version build as well as any variants.

Fixes #16.