### PR TITLE
Spit out aliases to a file

### DIFF
--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -112,4 +112,15 @@ for versionGroup in "$@"; do
 
 		echo "$string" >> ./build-images.sh
 	done
+
+	# Build out the ALIASES file. Keeps track of aliases that have been set
+	# without losing old versions.
+	if [[ -n $vgAlias1 ]]; then
+		if [[ -f ALIASES ]]; then
+			# Make sure the current alias isn't in the file.
+			grep -v "${vgAlias1}" ./ALIASES > ./TEMP && mv ./TEMP ./ALIASES
+		fi
+
+		echo "${vgAlias1}=${vgVersion}" >> ALIASES
+	fi
 done


### PR DESCRIPTION
Spits out each alias that may have been used to a file called ALIASES.
The file sticks around to track history so if an alias is to be added
that already exists in the file, it is overridden.

While this feature may be interesting in itself, it's mostly useful for
other systems to be able to programmatically come back later and
determine which aliases an image has without doing a ton of processing
via the Docker Hub API.