### PR TITLE
Refactored Check-Versions Script

### DIFF
--- a/check-versions.sh
+++ b/check-versions.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+echo "Checking Versioning"
+
+if [ -e ./ALIASES ]; then
+    git restore ALIASES --source=main
+    PREV_LTS="$(grep 'lts' ALIASES | cut -d "=" -f2)"
+    PREV_VERSION="$(grep 'current' ALIASES | cut -d "=" -f2)"
+    export PREV_LTS
+    export PREV_VERSION
+fi
+
+checkVersions() {
+    local currentVersion=$1
+    local prevVersion=$2
+    if ! [ -e ./ALIASES ]; then
+        echo "Skipping version check"
+    elif [[ $prevVersion != "$currentVersion" ]]; then
+        if [ "$(printf '%s\n' "$currentVersion" "$prevVersion" | sort -V | head -n1)" = "$currentVersion" ]; then
+            echo "Please check your versions. current: $currentVersion previous: $prevVersion"
+            exit 1
+        else
+            echo "Version check passed"
+        fi
+    else
+        echo "Same version detected"
+    fi
+}

--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -5,6 +5,10 @@
 
 # Import repo-specific image information
 source ./manifest
+# Import scripts that compares user version arguement with old alias file 
+# to determine if Dockerfiles will be generated
+source check-versions.sh
+chmod +x check-versions.sh
 tagless_image=${namespace}/${repository}
 
 # Prepare the build and push files. Originally we only needed a build file but
@@ -94,6 +98,13 @@ for versionGroup in "$@"; do
 
 	vgVersionFull=$(cut -d "v" -f2- <<< "$versionGroup")
 	vgVersion=$vgVersionFull  # will be deprecated in the future
+
+	# Version checking
+	if [[ $vgAlias1 == "lts" ]]; then
+		checkVersions "$vgVersion" "$PREV_LTS"
+	else
+		checkVersions "$vgVersion" "$PREV_VERSION"
+	fi
 
 	if [[ $vgVersionFull =~ ^[0-9]+\.[0-9]+ ]]; then
 		vgVersionMinor=${BASH_REMATCH[0]}

--- a/release.sh
+++ b/release.sh
@@ -2,6 +2,8 @@
 
 # Much of the version processing logic is repeated from gen-dockerfiles.sh
 # This should be de-duped sometime in the future when this logic is solidified
+
+source check-versions.sh
 versions=()
 
 for versionGroup in "$@"; do
@@ -21,6 +23,13 @@ for versionGroup in "$@"; do
 
 	vgVersion=$(cut -d "v" -f2- <<< "$versionGroup")
 	versions+=( "$vgVersion" )
+
+	# Version checking
+	if [[ $vgAlias1 == "lts" ]]; then
+		checkVersions "$vgVersion" "$PREV_LTS"
+	else
+		checkVersions "$vgVersion" "$PREV_VERSION"
+	fi
 done
 
 branchName=""


### PR DESCRIPTION
- Made check-versions a function in order to check across all cimg repos
- ALIASES file will be needed in all cimg repos even without aliases like LTS to track current versions (will still need to account for older versions)