### PR TITLE
added support for multiple parents

### DIFF
--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -77,7 +77,6 @@ build_and_push() {
 	echo "docker push $tagless_image:$versionShortString" >> ./push-images-temp.sh
 	echo "docker push $tagless_image:$versionString" >> ./push-images-temp.sh
 	echo "docker build --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString ." >> ./build-images-temp.sh
-
 }
 
 filepath_templating () {
@@ -132,7 +131,7 @@ for versionGroup in "$@"; do
 	# no parentTag loop; creates Dockerfiles and variants
 	if [[ -z "${parentTags[0]}" ]]; then
 		parse_template_variables "/" "$parent" "./Dockerfile.template" "$vgVersion" "$versionShort"
-		build_and_push "$versionShort/Dockerfile" "$vgVersion" "$versionShort"
+		build_and_push "$versionShort" "$vgVersion" "$versionShort"
 
 		for variant in "${variants[@]}"; do
 			filepath_templating

--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -130,7 +130,7 @@ for versionGroup in "$@"; do
 
 	# no parentTag loop; creates Dockerfiles and variants
 	if [[ -z "${parentTags[0]}" ]]; then
-		parse_template_variables "/" "$parent" "./Dockerfile.template" "$vgVersion" "$versionShort"
+		parse_template_variables "" "$parent" "./Dockerfile.template" "$vgVersion" "$versionShort"
 		build_and_push "$versionShort" "$vgVersion" "$versionShort"
 
 		for variant in "${variants[@]}"; do
@@ -144,7 +144,7 @@ for versionGroup in "$@"; do
 		for parentTag in "${parentTags[@]}"; do
 			if [[ -n $parentTag ]]; then
 				parse_template_variables "$parentTag/" "$parent" "./Dockerfile.template" "$parentTag" "$versionShort/$parentTag"
-				build_and_push "$versionShort/$parentTag/$variant" "$vgVersion-$parentSlug-$parentTag" "$versionShort-$parentSlug-$parentTag"
+				build_and_push "$versionShort/$parentTag" "$vgVersion-$parentSlug-$parentTag" "$versionShort-$parentSlug-$parentTag"
 				
 				for variant in "${variants[@]}"; do
 					filepath_templating

--- a/manifest
+++ b/manifest
@@ -7,3 +7,6 @@ repository=nothing
 parent=nothing
 variants=(nothing)
 namespace=nothing
+parentTags=(nothing)
+defaultParentTag=nothing
+parentSlug=nothing


### PR DESCRIPTION
- added 3 new variables to manifest:
-- parentTags supports Elixir and Clojure, allowing them to choose versions of Erlang and OpenJDK, respectively
-- defaultParentTag tracks the default tag for new version updates
-- parentSlug helps to differentiate from diverging repository/parent names and to help track for Dockerfile builds

- Refactored parser to take in variables and account for all cases
- Added build and push function to help generate Docker strings

- waiting on:
https://github.com/CircleCI-Public/cimg-clojure/pull/18
https://github.com/CircleCI-Public/cimg-elixir/pull/71

- Closes #51 