### PR TITLE
Fix alias tag regression

### DIFF
--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -94,7 +94,6 @@ build_and_push() {
 	if [[ -n $vgAlias1 ]] && [[ "$vgVersion" = "$aliasGroup" ]]; then
 		{
 			echo "docker tag $tagless_image:$versionString $tagless_image:$defaultString"
-			echo "docker tag $tagless_image:$versionShortString $tagless_image:$defaultString"
 			echo "docker push $tagless_image:$defaultString"
 		} >> ./push-images-temp.sh
 	fi

--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -79,6 +79,7 @@ build_and_push() {
 	# every version loop will generate these basic docker tags
 	# if parentTags are enabled, then additional tags will be generated in the parentTag loop
 	# the defaultString is referenced as the tag that should be given by default for either a parent Tag or an alias
+
 	echo "docker push $tagless_image:$versionShortString" >> ./push-images-temp.sh
 	echo "docker push $tagless_image:$versionString" >> ./push-images-temp.sh
 	echo "docker build --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString ." >> ./build-images-temp.sh
@@ -88,9 +89,10 @@ build_and_push() {
 		echo "docker tag $tagless_image:$versionShortString $tagless_image:$defaultShortString" >> ./push-images-temp.sh
 	fi
 	
-	if [[ -n $vgAlias1 ]]; then
+	if [[ -n $vgAlias1 ]] && [[ "$vgVersion" = "$aliasGroup" ]]; then
 		echo "docker tag $tagless_image:$versionString $tagless_image:$defaultString" >> ./push-images-temp.sh
 		echo "docker tag $tagless_image:$versionShortString $tagless_image:$defaultString" >> ./push-images-temp.sh
+		echo "docker push $tagless_image:$defaultString" >> ./push-images-temp.sh
 	fi
 }
 
@@ -121,6 +123,7 @@ for versionGroup in "$@"; do
 		vgAlias1=$(cut -d "=" -f2- <<< "$versionGroup")
 		versionGroup="${versionGroup//$vgAlias1}"
 		versionGroup="${versionGroup//=}"
+		aliasGroup="${versionGroup}"
 	fi
 
 	vgVersionFull=$(cut -d "v" -f2- <<< "$versionGroup")

--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -85,14 +85,18 @@ build_and_push() {
 	echo "docker build --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString ." >> ./build-images-temp.sh
 
 	if [[ -n $defaultParentTag ]] && [[ "$defaultParentTag" == "$parentTag" ]]; then
-		echo "docker tag $tagless_image:$versionString $tagless_image:$defaultString" >> ./push-images-temp.sh
-		echo "docker tag $tagless_image:$versionShortString $tagless_image:$defaultShortString" >> ./push-images-temp.sh
+		{ 
+			echo "docker tag $tagless_image:$versionString $tagless_image:$defaultString"
+			echo "docker tag $tagless_image:$versionShortString $tagless_image:$defaultShortString"
+		} >> ./push-images-temp.sh
 	fi
 	
 	if [[ -n $vgAlias1 ]] && [[ "$vgVersion" = "$aliasGroup" ]]; then
-		echo "docker tag $tagless_image:$versionString $tagless_image:$defaultString" >> ./push-images-temp.sh
-		echo "docker tag $tagless_image:$versionShortString $tagless_image:$defaultString" >> ./push-images-temp.sh
-		echo "docker push $tagless_image:$defaultString" >> ./push-images-temp.sh
+		{
+			echo "docker tag $tagless_image:$versionString $tagless_image:$defaultString"
+			echo "docker tag $tagless_image:$versionShortString $tagless_image:$defaultString"
+			echo "docker push $tagless_image:$defaultString"
+		} >> ./push-images-temp.sh
 	fi
 }
 

--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -78,7 +78,7 @@ build_and_push() {
 
 	# every version loop will generate these basic docker tags
 	# if parentTags are enabled, then additional tags will be generated in the parentTag loop
-	# the defaultString is referenced as the tag that should be given by defauly for either a parent Tag or an alias
+	# the defaultString is referenced as the tag that should be given by default for either a parent Tag or an alias
 	echo "docker push $tagless_image:$versionShortString" >> ./push-images-temp.sh
 	echo "docker push $tagless_image:$versionString" >> ./push-images-temp.sh
 	echo "docker build --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString ." >> ./build-images-temp.sh


### PR DESCRIPTION
closes #64

Initially, the new parentTag functionality did not support aliases (which are currently only present on cimg-node). As a result, alias tags like cimg/node:lts or cimg/node:browsers were not being tagged, causing confusion with customers.

This PR implements a fix by adding those tags back in through the docker tag command and is separated out by the different version loop workflows - one for parentTag functionality, and one for cimg's that do not have parentTag functionality
