### PR TITLE
adds check for aliasGroup

### DIFF
--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -177,7 +177,7 @@ for versionGroup in "$@"; do
 	fi
 	# Build out the ALIASES file. Keeps track of aliases that have been set
 	# without losing old versions.
-	if [[ -n $vgAlias1 ]]; then
+	if [[ -n $vgAlias1 ]] && [[ $aliasGroup = $versionGroup ]]; then
 		if [[ -f ALIASES ]]; then
 			# Make sure the current alias isn't in the file.
 			grep -v "${vgAlias1}" ./ALIASES > ./TEMP && mv ./TEMP ./ALIASES

--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -177,7 +177,7 @@ for versionGroup in "$@"; do
 	fi
 	# Build out the ALIASES file. Keeps track of aliases that have been set
 	# without losing old versions.
-	if [[ -n $vgAlias1 ]] && [[ $aliasGroup = $versionGroup ]]; then
+	if [[ -n $vgAlias1 ]] && [[ $aliasGroup = "$versionGroup" ]]; then
 		if [[ -f ALIASES ]]; then
 			# Make sure the current alias isn't in the file.
 			grep -v "${vgAlias1}" ./ALIASES > ./TEMP && mv ./TEMP ./ALIASES


### PR DESCRIPTION
the ALIAS file was updating the listed tags within the file if there was a vgAlias variable present, which is working as intended. However, the check means defining a tag like lts or current would make the condition true for subsequent tags/versions and inadvertently update the ALIAS file.

This check fixes that