### PR TITLE
update for defaultParentTag docker push string

### DIFF
--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -88,6 +88,8 @@ build_and_push() {
 		{ 
 			echo "docker tag $tagless_image:$versionString $tagless_image:$defaultString"
 			echo "docker tag $tagless_image:$versionShortString $tagless_image:$defaultShortString"
+			echo "docker push $tagless_image:$defaultShortString"
+			echo "docker push $tagless_image:$defaultString"
 		} >> ./push-images-temp.sh
 	fi
 	


### PR DESCRIPTION
defaultParentTag string to push the assumed parent Tag; e.g there are multiple language versions of erlang, but the one we want to be the default would be 25.0, when there are 22, 23, 24, etc. This explicitly pushes the 25.0 version after having tagged it to cimg/elixir:1.13.4-erlang-25.0 -> cimg/elixir:1.13.4