### PR TITLE
Adds GEN-CHECK for testing validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,10 @@
 version: 2.1
 
 orbs:
-  shell: circleci/shellcheck@1.3.10
+  shell: circleci/shellcheck@3.1.1
 
 workflows:
   lint-scripts:
     jobs:
-      - shell/check
+      - shell/check:
+          exclude: "SC1091,SC2128,SC2145,SC2154"

--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -17,6 +17,8 @@ echo "#!/usr/bin/env bash" > ./push-images.sh
 echo "# Do not edit by hand; please use build scripts/templates to make changes" >> ./push-images.sh
 chmod +x ./push-images.sh
 
+export CREATE_VERSIONS=("$@")
+
 # A version can be a major.minor or major.minor.patch version string.
 # An alias can be passed right after the version with an equal sign (=).
 # An additional parameter can be passed with a hash (#) sign.
@@ -191,6 +193,18 @@ for versionGroup in "$@"; do
 	# This .bak thing fixes a Linux/macOS compatibility issue, but the files are cleaned up
 	find . -name \*.bak -type f -delete
 done
+
+if [[ -n "${CREATE_VERSIONS}" ]]; then
+		# Make sure the current alias isn't in the file.
+	if [[ -f GEN-CHECK ]]; then
+		grep -v "${CREATE_VERSIONS}" ./GEN-CHECK > ./TEMP2 && mv ./TEMP2 ./GEN-CHECK
+	fi
+
+	echo "GEN_CHECK=($@)" > GEN-CHECK
+	if [[ -f TEMP2 ]]; then
+		rm ./TEMP2
+	fi
+fi
 
 cat -n push-images-temp.sh | sort -uk2 | sort -nk1 | cut -f2- >> push-images.sh
 cat -n build-images-temp.sh | sort -uk2 | sort -nk1 | cut -f2- >> build-images.sh


### PR DESCRIPTION
- Adds the GEN-CHECK file as a way for testing workflow to validate files and run gen-dockerfiles within the container
- updates shellcheck to version 3.1.1
- adds some exclusions since some behavior is intended; e.g $@ for array expansion as separate arguments