### PR TITLE
specify --platform linux/amd64 when build docker image

### DIFF
--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -84,7 +84,7 @@ build_and_push() {
 
 	echo "docker push $tagless_image:$versionShortString" >> ./push-images-temp.sh
 	echo "docker push $tagless_image:$versionString" >> ./push-images-temp.sh
-	echo "docker build --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString ." >> ./build-images-temp.sh
+	echo "docker build --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString --platform linux/amd64 ." >> ./build-images-temp.sh
 
 	if [[ -n $defaultParentTag ]] && [[ "$defaultParentTag" == "$parentTag" ]]; then
 		{ 


### PR DESCRIPTION
The `--platform linux/amd64` is now explicitly specified.

----
When trying to build cimg-ruby(browsers) or other packages on M1 mac, the following error may occur due to platforms not supported by some packages.

```
 => ERROR [6/6] RUN wget -q -O - "https://dl.google.com/linux/linux_signing_key.pub" | sudo apt-key add - && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list && sudo apt-get update && sudo apt-get install google-chrome-stable && sudo rm -rf /var/lib/apt/lists/* 8.3s 
```

This can be worked around by explicitly specifying the --platform option in the docker build.
