### PR TITLE
feat: checks if the branch already exists

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -48,8 +48,13 @@ fi
 
 defaultBranch=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
 
-git checkout -b "${branchName}" "${defaultBranch}"
-shared/gen-dockerfiles.sh "$@"
-git add .
-git commit -m "${commitMSG}"
-git push -u origin "${branchName}"
+if [[ -n $(git ls-remote --exit-code --heads origin "$branchName") ]]; then
+	echo "Branch already exists. Please check the branch or PR"
+	exit 1
+else
+	git checkout -b "${branchName}" "${defaultBranch}"
+	shared/gen-dockerfiles.sh "$@"
+	git add .
+	git commit -m "${commitMSG}"
+	git push -u origin "${branchName}"
+fi


### PR DESCRIPTION
this PR checks the remote to see if there currently exists a branch that would match the generated branch from ./release.sh.

since the automated flow will work on a scheduled pipeline, it's possible that the branch will exist and has not been reviewed or merged. the build will error out in the current state, but will specifically inform the branch exists and needs to be reviewed