### PR TITLE
Add buildx variant tag support

### DIFF
--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -93,9 +93,9 @@ build_and_push() {
 		echo "docker push $tagless_image:$versionString" >> ./push-images-temp.sh
 		echo "docker build --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString --platform linux/amd64 ." >> ./build-images-temp.sh
 	elif [[ $pathing == *"browsers"* ]]; then
-		echo "docker buildx build --platform=linux/amd64 --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString ." >> ./build-images-temp.sh
+		echo "docker buildx build --platform=linux/amd64 --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString --push ." >> ./build-images-temp.sh
 	else
-		echo "docker buildx build --platform=linux/amd64,linux/arm64 --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString ." >> ./build-images-temp.sh
+		echo "docker buildx build --platform=linux/amd64,linux/arm64 --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString --push ." >> ./build-images-temp.sh
 	fi
 
 	if [[ -n $defaultParentTag ]] && [[ "$defaultParentTag" == "$parentTag" ]]; then

--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -18,6 +18,7 @@ if [[ $arm64 == "1" ]]; then
 	echo "docker buildx create --use cimg"  >> ./build-images.sh
 fi
 
+touch push-images-temp.sh
 echo "#!/usr/bin/env bash" > ./push-images.sh
 echo "# Do not edit by hand; please use build scripts/templates to make changes" >> ./push-images.sh
 chmod +x ./push-images.sh
@@ -86,11 +87,10 @@ build_and_push() {
 	# every version loop will generate these basic docker tags
 	# if parentTags are enabled, then additional tags will be generated in the parentTag loop
 	# the defaultString is referenced as the tag that should be given by default for either a parent Tag or an alias
-
-	echo "docker push $tagless_image:$versionShortString" >> ./push-images-temp.sh
-	echo "docker push $tagless_image:$versionString" >> ./push-images-temp.sh
-
+	
 	if [[ -z "$arm64" ]]; then
+		echo "docker push $tagless_image:$versionShortString" >> ./push-images-temp.sh
+		echo "docker push $tagless_image:$versionString" >> ./push-images-temp.sh
 		echo "docker build --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString --platform linux/amd64 ." >> ./build-images-temp.sh
 	elif [[ $pathing == *"browsers"* ]]; then
 		echo "docker buildx build --platform=linux/amd64 --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString ." >> ./build-images-temp.sh
@@ -99,19 +99,27 @@ build_and_push() {
 	fi
 
 	if [[ -n $defaultParentTag ]] && [[ "$defaultParentTag" == "$parentTag" ]]; then
-		{ 
-			echo "docker tag $tagless_image:$versionString $tagless_image:$defaultString"
-			echo "docker tag $tagless_image:$versionShortString $tagless_image:$defaultShortString"
-			echo "docker push $tagless_image:$defaultShortString"
-			echo "docker push $tagless_image:$defaultString"
-		} >> ./push-images-temp.sh
+		if [[ -z "$arm64" ]]; then
+			{ 
+				echo "docker tag $tagless_image:$versionString $tagless_image:$defaultString"
+				echo "docker tag $tagless_image:$versionShortString $tagless_image:$defaultShortString"
+				echo "docker push $tagless_image:$defaultShortString"
+				echo "docker push $tagless_image:$defaultString"
+			} >> ./push-images-temp.sh
+		fi
 	fi
 	
 	if [[ -n $vgAlias1 ]] && [[ "$vgVersion" = "$aliasGroup" ]]; then
-		{
-			echo "docker tag $tagless_image:$versionString $tagless_image:$defaultString"
-			echo "docker push $tagless_image:$defaultString"
-		} >> ./push-images-temp.sh
+		if [[ -z "$arm64" ]]; then
+			{
+				echo "docker tag $tagless_image:$versionString $tagless_image:$defaultString"
+				echo "docker push $tagless_image:$defaultString"
+			} >> ./push-images-temp.sh
+		else
+			{
+				echo "docker buildx imagetools create -t $tagless_image:$defaultString $tagless_image:$versionString"
+			} >> ./push-images-temp.sh
+		fi
 	fi
 }
 


### PR DESCRIPTION
This PR adjusts how gen-dockerfiles works for buildx enabled repos. It will now push the main version tags from the buildx command directly (as build and push cannot be split easily in buildx) and use the push-images.sh file to push the variant tags.

Example `build-images.sh`

```bash
#!/usr/bin/env bash
# Do not edit by hand; please use build scripts/templates to make changes
docker context create cimg
docker buildx create --use cimg
docker buildx build --platform=linux/amd64,linux/arm64 --file 20.4/Dockerfile -t cimg/node:20.4.0 -t cimg/node:20.4 --push .
docker buildx build --platform=linux/amd64 --file 20.4/browsers/Dockerfile -t cimg/node:20.4.0-browsers -t cimg/node:20.4-browsers --push .
docker buildx build --platform=linux/amd64,linux/arm64 --file 18.16/Dockerfile -t cimg/node:18.16.1 -t cimg/node:18.16 --push .
docker buildx build --platform=linux/amd64 --file 18.16/browsers/Dockerfile -t cimg/node:18.16.1-browsers -t cimg/node:18.16-browsers --push .
```

Example `push-images.sh`

```bash
#!/usr/bin/env bash
# Do not edit by hand; please use build scripts/templates to make changes
docker buildx imagetools create -t cimg/node:current cimg/node:20.4.0
docker buildx imagetools create -t cimg/node:current-browsers cimg/node:20.4.0-browsers
docker buildx imagetools create -t cimg/node:lts cimg/node:18.16.1
docker buildx imagetools create -t cimg/node:lts-browsers cimg/node:18.16.1-browsers
```

This could be better consolidated into a single file in the future (or add variant tags to the buildx commands), but for now, while we support both traditional builds and buildx, this seems like the best solution.