### PR TITLE
Fix: Enabled browser variants for arm64

### DIFF
--- a/gen-dockerfiles.sh
+++ b/gen-dockerfiles.sh
@@ -108,8 +108,6 @@ build_and_push() {
 		echo "docker push $tagless_image:$versionShortString" >> ./push-images-temp.sh
 		echo "docker push $tagless_image:$versionString" >> ./push-images-temp.sh
 		echo "docker build --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString --platform linux/amd64 ." >> ./build-images-temp.sh
-	elif [[ $pathing == *"browsers"* ]]; then
-		echo "docker buildx build --platform=linux/amd64 --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString --push ." >> ./build-images-temp.sh
 	else
 		echo "docker buildx build --platform=linux/amd64,linux/arm64 --file $pathing/Dockerfile -t $tagless_image:$versionString -t $tagless_image:$versionShortString --push ." >> ./build-images-temp.sh
 	fi

--- a/variants/browsers.Dockerfile.template
+++ b/variants/browsers.Dockerfile.template
@@ -5,10 +5,11 @@ FROM %%NAMESPACE%%/%%PARENT%%:%%PARENT_TAG%%-node
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 
 # Install Selenium
-ENV SELENIUM_VER=3.141.59
-RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
-    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
-    rm selenium-server-standalone-${SELENIUM_VER}.jar
+ENV SELENIUM_VER=4.14.1
+
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://github.com/SeleniumHQ/selenium/releases/download/selenium-server-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-${SELENIUM_VER}.jar
 
 RUN sudo apt-get update && \
 	sudo apt-get install --yes --no-install-recommends \
@@ -53,10 +54,13 @@ RUN echo 'Package: *' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
 # regularly updated thing. Instead, if this version of Chrome isn't what the
 # end user wants they should install a different version via the Browser Tools
 # Orb.
-RUN wget -q -O - "https://dl.google.com/linux/linux_signing_key.pub" | sudo apt-key add - && \
-	echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list && \
-	sudo apt-get update && \
-	sudo apt-get install google-chrome-stable && \
+# Note: Chrome is only packaged for amd64, so we do not install it for arm64
+RUN [[ $(uname -m) == "x86_64" ]]; then \
+		wget -q -O - "https://dl.google.com/linux/linux_signing_key.pub" | sudo apt-key add - && \
+		echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list && \
+		sudo apt-get update && \
+		sudo apt-get install google-chrome-stable; \
+	fi && \
 	sudo rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
This PR enables arm64 images to have browser variants.

This is achieved by using the latest Selenium server.

Note: This needs to be tested further before approval as the newer version of selenium server has a breaking change. To echo the way it used to function, it now needs to be called as `java -jar /usr/local/bin/selenium.jar standalone` rather than just `java -jar /usr/local/bin/selenium.jar`

Also note: Chrome install is skipped as packages are not available.

Opening this PR for review now, but we should hold back on merging until it is thoroughly checked over. I plan to run some test image builds and run them against sample projects. This may require adjustments to the browser tools orb too(?)