### PR TITLE
[PROV-444] feat: add intervals for dated tags

### DIFF
--- a/automated-updates.sh
+++ b/automated-updates.sh
@@ -167,9 +167,6 @@ replaceVersions() {
   fi
 }
 
-###
-  # generateDatedTags generates tags in the form '2023.03'
-###
 declare -A quarters
 quarters["01"]="01"
 quarters["04"]="04"
@@ -178,28 +175,33 @@ quarters["10"]="10"
 
 export quarters
 
+###
+  # generateDatedTags generates tags in the form '2023.03'
+###
 generateDatedTags() {
   CURRENTMONTH=$(date +%m)
   CURRENTYEAR=$(date +%Y)
   RELEASE="$CURRENTYEAR.$CURRENTMONTH"
+
   export RELEASE
 }
 
-# Check the mont
 checkMonth() {
   if [[ ${quarters[${RELEASE##*.}]+exists} && $TEMPLATEMONTH != "${RELEASE##*.}" ]]; then
     STRING_TO_REPLACE="$TEMPLATEYEAR.$TEMPLATEMONTH"
   fi
-  export STRING_TO_REPLACE
 }
 
 replaceDatedTags() {
   local templateFile=$1
+  local interval=$2
   TEMPLATEYEAR=$(grep -m 1 "FROM" "$templateFile" | head -1 | cut -d : -f2 | cut -d . -f1)
-  TEMPLATEMONTH=$(grep -m 1 "FROM" "$templateFile" | head -1 | cut -d : -f2 | cut -d . -f2)
+  TEMPLATEMONTH=$(grep -m 1 "FROM" "$templateFile" | head -1 | cut -d : -f2 | cut -d . -f2 | cut -d - -f1)
 
   generateDatedTags
   checkMonth
 
+  [[ $interval == "monthly" ]] && STRING_TO_REPLACE="$TEMPLATEYEAR.$TEMPLATEMONTH"
   [[ -n $STRING_TO_REPLACE ]] && sed -i.bak "s|$STRING_TO_REPLACE|$RELEASE|g" "$templateFile"
+  rm -rf ./*.bak
 }

--- a/automated-updates.sh
+++ b/automated-updates.sh
@@ -190,6 +190,8 @@ checkMonth() {
   if [[ ${quarters[${RELEASE##*.}]+exists} && $TEMPLATEMONTH != "${RELEASE##*.}" ]]; then
     STRING_TO_REPLACE="$TEMPLATEYEAR.$TEMPLATEMONTH"
   fi
+
+  export STRING_TO_REPLACE
 }
 
 replaceDatedTags() {


### PR DESCRIPTION
- add support for automatically replacing quarterly versions of parent cimgs. this is generally meant to affect images built off of cimg/base and is defined in the [manifest](https://github.com/CircleCI-Public/cimg-openjdk/blob/main/manifest). some exceptions, like [clojure](https://github.com/CircleCI-Public/cimg-clojure/blob/main/manifest) build off something different
- add support for changing parent versions of monthly releases like `cimg/gcp`, `cimg/aws`, `cimg/azure`, which are based off cimg-deploy
- fixes a problem with sed creating a .bak file which we do not want to include as part of an automated PR